### PR TITLE
Support gtfo_force_iterm property.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -57,6 +57,11 @@ see if some other plugin is using that mapping.
 
     let g:gtfo_cygwin_bash = 'C:\cygwin\bin\bash'
 
+* `g:gtfo_force_iterm` : if set, forces use of iTerm.app on the Mac. This can
+  be useful when MacVim is running in GUI mode rather than the terminal, where
+  gtfo cannot easily detect whether iTerm is being used by the user as the
+  "standard" terminal.
+
 ### Installation
 
 Same installation as most Vim plugins, or use a plugin manager:

--- a/plugin/gtfo.vim
+++ b/plugin/gtfo.vim
@@ -122,7 +122,7 @@ func! gtfo#openterm(dir, cmd) "{{{
       silent exe '!start '.$COMSPEC.' /k "cd "'.l:dir.'""'
     endif
   elseif s:ismac
-    if $TERM_PROGRAM ==? 'iTerm.app'
+    if $TERM_PROGRAM ==? 'iTerm.app' || exists('g:gtfo_force_iterm')
       silent call <sid>mac_open_iTerm(l:dir)
     else
       silent exec "!open -a Terminal '".l:dir."'"


### PR DESCRIPTION
I'm suggesting introducing a new property for use by Vim on the Mac when it's used in GUI mode, which enables it to know to use iTerm rather than the system-default terminal. Since I suspect this is a popular combination, hopefully you think this would be useful?
