### PR TITLE
Open a new tab in iTerm instead of a new window

### DIFF
--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -166,8 +166,8 @@ endf
 func! s:mac_open_iTerm(expanded_dir)
   let l:cmd = "
         \ tell application 'iTerm'                             \n
-        \   set term to (make new terminal)                    \n
-        \   tell term                                          \n
+        \   make new terminal                                  \n
+        \   tell the current terminal                          \n
         \     set sess to (launch session 'Default Session')   \n
         \     tell sess                                        \n
         \       write text '___'                               \n


### PR DESCRIPTION
When an iTerm session exists, this creates a new tab in activated window. Also it works when iTerm is not running and user typed `got` in Terminal.app with `let g:gtfo#terminals = { 'mac' : 'iterm' }`.
