### PR TITLE
Pass the directory to tmux as an option

### DIFF
--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -122,7 +122,7 @@ func! gtfo#open#term(dir, cmd) "{{{
   endif
 
   if s:istmux
-    silent call system('tmux split-window -h \; send-keys "cd ''' . l:dir . ''' && clear" C-m')
+    silent call system('tmux split-window -h -c "' . l:dir . '"')
   elseif &shell !~? "cmd" && executable('cygstart') && executable('mintty')
     " https://code.google.com/p/mintty/wiki/Tips
     silent exec '!cd ''' . l:dir . ''' && cygstart mintty /bin/env CHERE_INVOKING=1 /bin/bash'


### PR DESCRIPTION
Other than being shorter, from the usage perspective we don't see the `cd` command that shows for a split second anymore.

I wasn't sure how I should handle directories with spaces, but I tested this with a directory with space in it, and it worked.
