### PR TITLE
Update iTerm script

### DIFF
--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -139,7 +139,7 @@ func! gtfo#open#term(dir, cmd) "{{{
     call s:restore_shell()
   elseif s:ismac
     if (s:empty(s:termpath) && $TERM_PROGRAM ==? 'iTerm.app') || s:termpath ==? "iterm"
-      silent call s:mac_open_iTerm(l:dir)
+      silent call system("open -a iTerm '".l:dir."'")
     else
       if s:empty(s:termpath) | let s:termpath = 'Terminal' | endif
       silent call system("open -a ".s:termpath." '".l:dir."'")
@@ -157,45 +157,5 @@ func! gtfo#open#term(dir, cmd) "{{{
     call s:beep('failed to open terminal')
   endif
 endf "}}}
-
-if s:ismac "{{{
-func! s:mac_do_ascript_voodoo(cmd, expanded_dir)
-  "This is somewhat complicated because we must pass a correctly-escaped,
-  "newline-delimitd applescript literal from vim => shell => osascript.
-
-  "Applescript does not allow apostrophes; we use them only for readability.
-  "replace ' with \"'
-  let l:cmd = substitute(a:cmd,  "'", '\\"', 'g')
-  "replace ___ with the shell command to be passed from applescript to Terminal.app.
-  let l:cmd = substitute(l:cmd, '___', "cd '".a:expanded_dir."'", 'g')
-  call system('osascript -e " ' . l:cmd . '"')
-endf
-
-func! s:mac_open_terminal(expanded_dir)
-  let l:cmd = "
-        \ tell application 'Terminal'     \n
-        \   do script with command '___'  \n
-        \   activate                      \n
-        \ end tell                        \n
-        \ "
-  call s:mac_do_ascript_voodoo(l:cmd, a:expanded_dir)
-endf
-
-func! s:mac_open_iTerm(expanded_dir)
-  let l:cmd = "
-        \ tell application 'iTerm'                             \n
-        \   make new terminal                                  \n
-        \   tell the current terminal                          \n
-        \     set sess to (launch session 'Default Session')   \n
-        \     tell sess                                        \n
-        \       write text '___'                               \n
-        \     end tell                                         \n
-        \   end tell                                           \n
-        \   activate                                           \n
-        \ end tell                                             \n
-        \ "
-  call s:mac_do_ascript_voodoo(l:cmd, a:expanded_dir)
-endf
-endif "}}}
 
 call s:init()


### PR DESCRIPTION
iTerm2 made some changes to its scripting, which causes 'got' to silently fail when using iTerm2, and setting
let g:gtfo#terminals = { 'mac' : 'iterm' }

Here is the new scripting commands:
https://github.com/gnachman/iTerm2/blob/master/iTerm2.sdef

Perhaps it might be necessary to check and have separate scripts  for iTerm/iTerm2.
Thoughts?
