### PR TITLE
Fix inheritance problems in gnome-terminal

### DIFF
--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -179,7 +179,7 @@ func! gtfo#open#term(dir, cmd) abort "{{{
     if !s:empty(s:termpath)
       silent call system(s:termpath." ".shellescape(l:dir))
     elseif executable('gnome-terminal')
-      silent call system('gnome-terminal --app-id=org.gnome.Terminal --window --working-directory "'. l:dir . '"')
+      silent call system('gnome-terminal --app-id=org.gnome.Terminal --window --working-directory '''. l:dir . '''')
     else
       call s:beep('failed to open terminal')
     endif

--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -179,7 +179,7 @@ func! gtfo#open#term(dir, cmd) abort "{{{
     if !s:empty(s:termpath)
       silent call system(s:termpath." ".shellescape(l:dir))
     elseif executable('gnome-terminal')
-      silent call system('gnome-terminal --window -e "$SHELL -c \"cd '''.l:dir.''' ; exec $SHELL\""')
+      silent call system('gnome-terminal --app-id=org.gnome.Terminal --window --working-directory "'. l:dir . '"')
     else
       call s:beep('failed to open terminal')
     endif


### PR DESCRIPTION
Also, use the `--working-directory` flag instead of executing `cd`.

Fixes #45.

Tested with gnome-terminal 3.28, 3.30 and 3.32.