### PR TITLE
add support for wezterm

### DIFF
--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -1,6 +1,7 @@
 let s:iswin = has('win32') || has('win64') || has('win32unix') || has('win64unix')
 let s:ismac = has('gui_macvim') || has('mac')
 let s:istmux = !(empty($TMUX))
+let s:iswezterm = $WEZTERM_PANE !=? ''
 "GUI Vim
 let s:isgui = has('gui_running') || &term ==? 'builtin_gui'
 "non-GUI Vim running within a GUI environment
@@ -141,6 +142,8 @@ func! gtfo#open#term(dir, cmd) abort "{{{
     else
       silent call system("tmux split-window -h -c '" . l:dir . "'")
     endif
+  elseif s:iswezterm
+    silent call system("wezterm cli split-pane --horizontal=false --cwd='" . l:dir . "'")
   elseif &shell !~? "cmd" && executable('cygstart') && executable('mintty')
     " https://github.com/mintty/mintty/wiki/Tips
     silent exec '!cd '.shellescape(l:dir, 1).' && cygstart mintty /bin/env CHERE_INVOKING=1 /bin/bash'

--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -143,7 +143,8 @@ func! gtfo#open#term(dir, cmd) abort "{{{
       silent call system("tmux split-window -h -c '" . l:dir . "'")
     endif
   elseif s:iswezterm
-    silent call system("wezterm cli split-pane --horizontal=false --cwd='" . l:dir . "'")
+    let l:cwd = s:iswin ? shellescape(l:dir, 1) : "'" . l:dir .  "'"
+    silent call system("wezterm cli split-pane --horizontal=false --cwd=" . l:cwd)
   elseif &shell !~? "cmd" && executable('cygstart') && executable('mintty')
     " https://github.com/mintty/mintty/wiki/Tips
     silent exec '!cd '.shellescape(l:dir, 1).' && cygstart mintty /bin/env CHERE_INVOKING=1 /bin/bash'


### PR DESCRIPTION
refer to https://github.com/wez/wezterm/issues/230

If inside wezterm it opens a split pane when using open terminal by default which is similar to tmux.

I have tested it on Windows and Linux.

I can't use `empty($WEZTERM_PANE)` because the first pane is 0 and will evaluate to false hence I explicitly check for empty string.