### PR TITLE
add kitty support

### DIFF
--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -2,6 +2,7 @@ let s:iswin = has('win32') || has('win64') || has('win32unix') || has('win64unix
 let s:ismac = has('gui_macvim') || has('mac')
 let s:istmux = !(empty($TMUX))
 let s:iswezterm = $WEZTERM_PANE !=? ''
+let s:iskitty = $KITTY_LISTEN_ON !=? ''
 "GUI Vim
 let s:isgui = has('gui_running') || &term ==? 'builtin_gui'
 "non-GUI Vim running within a GUI environment
@@ -142,6 +143,9 @@ func! gtfo#open#term(dir, cmd) abort "{{{
     else
       silent call system("tmux split-window -h -c '" . l:dir . "'")
     endif
+  elseif s:iskitty
+    let l:cwd = s:iswin ? shellescape(l:dir, 1) : "'" . l:dir .  "'"
+    silent call system("kitty @ --to=$KITTY_LISTEN_ON new-window --cwd=" . l:cwd)
   elseif s:iswezterm
     let l:cwd = s:iswin ? shellescape(l:dir, 1) : "'" . l:dir .  "'"
     silent call system("wezterm cli split-pane --horizontal=false --cwd=" . l:cwd)

--- a/doc/vim-gtfo.txt
+++ b/doc/vim-gtfo.txt
@@ -31,6 +31,10 @@ OPTIONS                                                         *gtfo-options*
 PLATFORM SUPPORT                                       *gtfo-platform_support*
 
 *   tmux: `got` opens a new tmux pane.
+*   wezterm: `got` opens a new wezterm pane.
+*   kitty: `got` opens a new kitty pane if `allow_remote_control` and `listen_on`
+           are set to appropriate values in your kitty config.
+           See https://sw.kovidgoyal.net/kitty/remote-control
 *   mintty (Git-for-Windows (https://gitforwindows.org/),
     Cygwin (http://www.cygwin.com/), etc.): `got` opens a new mintty console.
 *   Windows


### PR DESCRIPTION
This adds a special case for kitty, just like #55 does for wezterm. It opens a (vertical) split