### PR TITLE
Remove wezterm's `--horizontal=false` argument.

### DIFF
--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -148,7 +148,7 @@ func! gtfo#open#term(dir, cmd) abort "{{{
     silent call system("kitty @ --to=$KITTY_LISTEN_ON new-window --cwd=" . l:cwd)
   elseif s:iswezterm
     let l:cwd = s:iswin ? shellescape(l:dir, 1) : "'" . l:dir .  "'"
-    silent call system("wezterm cli split-pane --horizontal=false --cwd=" . l:cwd)
+    silent call system("wezterm cli split-pane --cwd=" . l:cwd)
   elseif &shell !~? "cmd" && executable('cygstart') && executable('mintty')
     " https://github.com/mintty/mintty/wiki/Tips
     silent exec '!cd '.shellescape(l:dir, 1).' && cygstart mintty /bin/env CHERE_INVOKING=1 /bin/bash'


### PR DESCRIPTION
This style has been removed, --horizontal=true is now --horizontal and --horizontal=false is the default behaviour