### PR TITLE
add support for pwsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Platform Support
     * `gof` opens Windows Explorer.
     * `got` opens `g:gtfo#terminals['win']` *or* the first terminal it can find:
       "Git bash", mintty, or cmd.exe.
+    * To use pwsh:
+      ```
+      let g:gtfo#terminals = { 'win': 'pwsh' }
+      ```
     * To use powershell:
       ```
       let g:gtfo#terminals = { 'win': 'powershell -NoLogo -NoExit -Command' }

--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -173,6 +173,8 @@ func! gtfo#open#term(dir, cmd) abort "{{{
       silent exe '!start /min '.$COMSPEC.' /c "'.cdcmd.' & "'.s:termpath.'" - " & exit'
     elseif s:termpath =~? 'powershell' && executable('powershell')
       silent exe '!start '.s:termpath.' \"'.cdcmd.'\"'
+    elseif s:termpath =~? 'pwsh' && executable('pwsh')
+      silent exe '!start '.s:termpath.' -wd '.shellescape(l:dir,1)
     else "Assume it is a path-plus-arguments.
       if s:empty(s:termpath) | let s:termpath = 'cmd.exe /k'  | endif
       " This will nest quotes (""foo" "bar""), and yes, that is what cmd.exe expects.


### PR DESCRIPTION
`pwsh --help`
> -WorkingDirectory | -wd
> 
>     Sets the initial working directory by executing at startup. Any valid
>     PowerShell file path is supported.
> 
>     To start PowerShell in your home directory, use: pwsh -WorkingDirectory ~
