### PR TITLE
Add option to disable kitty integration

### DIFF
--- a/autoload/gtfo/open.vim
+++ b/autoload/gtfo/open.vim
@@ -30,6 +30,8 @@ func! s:init() abort
   let g:gtfo#terminals = extend(get(g:, "gtfo#terminals", {}),
         \ { 'win' : '', 'mac' : '', 'unix': '' }, 'keep')
 
+  let g:gtfo#kitty_integration = get(g:, "gtfo#kitty_integration", 1)
+
   if s:iswin
     let s:termpath = s:empty(g:gtfo#terminals.win) ? s:find_cygwin_bash() : g:gtfo#terminals.win
   elseif s:ismac
@@ -143,7 +145,7 @@ func! gtfo#open#term(dir, cmd) abort "{{{
     else
       silent call system("tmux split-window -h -c '" . l:dir . "'")
     endif
-  elseif s:iskitty
+  elseif s:iskitty && g:gtfo#kitty_integration
     let l:cwd = s:iswin ? shellescape(l:dir, 1) : "'" . l:dir .  "'"
     silent call system("kitty @ --to=$KITTY_LISTEN_ON new-window --cwd=" . l:cwd)
   elseif s:iswezterm

--- a/doc/vim-gtfo.txt
+++ b/doc/vim-gtfo.txt
@@ -26,6 +26,8 @@ OPTIONS                                                         *gtfo-options*
 >
         let g:gtfo#terminals = { 'mac': 'iterm' }
 <
+*   `g:gtfo#kitty_integration` Optional flag to enable or disable kitty
+    integration. Defaults to 1.
 
 --------------------------------------------------------------------------------
 PLATFORM SUPPORT                                       *gtfo-platform_support*


### PR DESCRIPTION
I wanted to open kitty in its own window. My understanding is that this was not possible with the current implementation.

This adds an option to disable kitty integration. Then the user can set the `unix` terminal to kitty and open a new window.

Thanks!